### PR TITLE
Fix non-ascii character

### DIFF
--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -566,7 +566,7 @@ order to be applied.
 ## Encodings for Weierstrass curves
 
 The following encodings apply to elliptic curves defined as E: y^2 = x^3+Ax+B,
-where 4A^3+27B^2 ≠ 0.
+where 4A^3+27B^2 != 0.
 
 
 ### Icart Method {#icart}


### PR DESCRIPTION
≠ symbol appears as `&#8800;` in the HTML version