### PR TITLE
hash2base update

### DIFF
--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1040,17 +1040,20 @@ Steps:
 
 ## Interface
 
-The generic interface for deterministic encoding functions to elliptic curves is as follows:
+The generic interface shared by all encodings in this section is as follows:
 
 ~~~
 (x, y) = map2curve(alpha, ctr=0)
 ~~~
 
-alpha is an octet string to be hashed to a point on the curve with affine
-coordinates (x, y) defined over F.
+Inputs:
 
-ctr is an integer in \[0, 255\] that is passed to hash2base. If not specified,
-ctr SHOULD default to 0.
+- alpha is an octet string to be hashed to a point on the curve with affine coordinates (x, y) defined over F.
+
+- ctr is an integer in \[0, 255\] that is passed to hash2base.
+  This argument is used in {{rom}} to efficiently construct orthogonal mappings.
+  If not specified, ctr SHOULD default to 0.
+
 
 ## Notation
 
@@ -1134,11 +1137,7 @@ The function map2curve\_icart(alpha) implements the Icart encoding method from {
 Preconditions: An elliptic curve over F, such that p>3 and q=p^m=2 (mod 3), or
 p=2 (mod 3) and odd m.
 
-Input: alpha, an octet string to be hashed.
-
 Constants: A and B, the parameters of the Weierstrass curve.
-
-Output: (x, y), a point on E.
 
 Sign of y: this encoding does not compute a square root, so there
 is no ambiguity regarding the sign of y.
@@ -1205,16 +1204,12 @@ al. {{BCIMRT10}}, which they call the "simplified SWU" map. Wahby and Boneh
 
 Preconditions: A Weierstrass curve over F such that A!=0 and B!=0.
 
-Input: alpha, an octet string to be hashed.
-
 Constants:
 
 - A and B, the parameters of the Weierstrass curve.
 
 - Z, the smallest (in absolute value) non-square in F such that g(B / (Z *
   A)) is square in F, breaking ties by choosing the positive value.
-
-Output: (x, y), a point on E.
 
 Sign of y: for u = hash2base(alpha), this encoding ignores the sign of u.
 Thus, we set sgn0(y) == sgn0(u).
@@ -1297,16 +1292,12 @@ and A^2 - 4 * B is non-square in F.
 
 Preconditions: A Montgomery curve where A != 0, B != 0, and A^2 - 4 is non-square in F.
 
-Input: alpha, an octet string to be hashed.
-
 Constants:
 
 - A and B, the parameters of the curve
 
 - Z, the smallest (in absolute value) non-square in F, breaking ties by choosing
   the positive value.
-
-Output: (x, y), a point on E.
 
 Sign of y: for u = hash2base(alpha), this encoding ignores the sign of u.
 Thus, we set sgn0(y) == sgn0(u).
@@ -1443,16 +1434,12 @@ invert the product y' * (B' * x' + 1), then multiply by y' to obtain
 
 Preconditions: A twisted Edwards curve.
 
-Input: alpha, an octet string to be hashed.
-
 Constants:
 
 - A and B, the parameters of the equivalent Montgomery curve, and B' = 1 / sqrt(B).
 
 - Z, the smallest (in absolute value) non-square in F, breaking ties by choosing
   the positive value.
-
-Output: (x, y), a point on E.
 
 Sign of y: for this map, the sign is determined by map2curve_elligator2.
 No further sign adjustments are required.
@@ -1490,11 +1477,7 @@ that q=2 (mod 3).
 
 Preconditions: A supersingular curve over F such that q=2 (mod 3).
 
-Input: alpha, an octet string to be hashed.
-
 Constants: B, the parameter of the supersingular curve.
-
-Output: (x, y), a point on E.
 
 Sign of y: determined by sign of u. No adjustments are necessary.
 
@@ -1538,11 +1521,7 @@ The function map2curve\_ell2A0(alpha) implements an adaptation of Elligator 2
 
 Preconditions: A supersingular curve over F such that q=3 (mod 4).
 
-Input: alpha, an octet string to be hashed.
-
 Constants: B, the parameter of the supersingular curve.
-
-Output: (x, y), a point on E.
 
 Sign of y: for u = hash2base(alpha), u and -u give the same x-coordinate.
 Thus, we set sgn0(y) == sgn0(u).
@@ -1606,16 +1585,12 @@ described in {{simple-swu-pairing-friendly}} is faster, when it applies.)
 
 Preconditions: An elliptic curve y^2 = g(x) = x^3 + B over F such that q=1 (mod 3) and B != 0.
 
-Input: alpha, an octet string to be hashed.
-
 Constants:
 
 - B, the parameter of the Weierstrass curve
 - Z, the smallest (in absolute value) element of F such that
   g((sqrt(-3 * Z^2) - Z) / 2) is square, breaking ties by choosing
   the positive value.
-
-Output: (x, y), a point on E.
 
 Sign of y: for u = hash2base(alpha), this encoding ignores the sign of u.
 Thus, we set sgn0(y) == sgn0(u).
@@ -1722,8 +1697,6 @@ Preconditions: An elliptic curve E' with A' != 0 and B' != 0 that is
 isogenous to the target curve E with isogeny map iso\_map(x, y) from
 E' to E.
 
-Input: alpha, an octet string to be hashed.
-
 Helper functions:
 
 - map2curve\_simple\_swu is the encoding of {{simple-swu}} to E'
@@ -1735,8 +1708,6 @@ of iso\_map must include its sign.)
 
 Exceptions: map2curve\_simple\_swu handles its exceptional cases.
 In the exceptional cases for iso\_map, it should return the identity point on E.
-
-Output: (x, y), a point on E.
 
 Operations:
 

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -976,7 +976,7 @@ the hash function H should be b >= 2 * k, where k is the target security
 level in bits. For example, for 128-bit security, b >= 256 bits; in this
 case, SHA256 would be an appropriate choice for H.
 
-Ensuring that the hash2base output is a uniform random element of H requires
+Ensuring that the hash2base output is a uniform random element of F requires
 care, even when H outputs a uniformly random string, as is generally assumed
 (in other words, even when modeling H as a random oracle). For example,
 if H=SHA256 and F is a field of characteristic p = 2^255 - 19, then the
@@ -994,8 +994,9 @@ a 256-bit prime, W = ceil((256 + 128) / 256) = 2.
 
 {{hash2base-impl}} details the hash2base procedure.
 
-Note that implementors SHOULD NOT use an iterated procedure, i.e., rejection
-sampling. The reason is that these procedures are difficult to implement in constant time,
+Note that implementors SHOULD NOT use rejection sampling to generate a uniformly
+random element of F.
+The reason is that these procedures are difficult to implement in constant time,
 and later well-meaning "optimizations" may silently render an implementation
 non-constant-time.
 

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -981,8 +981,8 @@ care, even when H outputs a uniformly random string, as is generally assumed
 (in other words, even when modeling H as a random oracle). For example,
 if H=SHA256 and F is a field of characteristic p = 2^255 - 19, then the
 result of reducing H(msg) (a 256-bit integer) modulo p is slightly more likely
-to be a value in \[0, 38\] than a value in \[39, 2^255 - 19). In this example
-the bias is negligible, but in general it can be significant.
+to be in \[0, 38\] than if the value were selected uniformly at random.
+In this example the bias is negligible, but in general it can be significant.
 
 To control bias, the input msg should be hashed to an integer comprising at
 least ceil(log2(p)) + k bits; reducing this integer modulo p gives bias at

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1748,10 +1748,10 @@ compute the following:
 ~~~
 u0 = hash2base(alpha, 0)
 u1 = hash2base(alpha, 1)
-(x, y) = map2curve(u0) (+) map2curve(u1)
+(x, y) = map2curve(u0) + map2curve(u1)
 ~~~
 
-where map2curve is the chosen encoding and the (+) operation is elliptic
+where map2curve is the chosen encoding and the addition operation is elliptic
 curve point addition.
 
 As described in {{hash2base-perf}}, implementors MAY factor the common

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1038,7 +1038,7 @@ Parameters:
 
 Inputs:
 - msg is the message to hash.
-- ctr is an integer argument, 0 <= ctr < 256.
+- ctr is either 0 or 1.
   This is used to efficiently create independent
   instances of hash2base (see discussion above).
 
@@ -1067,19 +1067,18 @@ The generic interface shared by all encodings in this section is as follows:
 The output (x, y) specifies a point on an elliptic curve defined over base field F;
 x and y are elements of F.
 
-The input u is an element of F that MUST be the output of the hash2base function
-({{hashtobase}}). The argument ctr to hash2base SHOULD be 0, except as described
-in {{rom}}.
-
-Thus, to map an octet string alpha to a point (x, y) using any of the encodings
-in this section, compute
+The input u is an element of F that MUST be the output of the hash2base
+function ({{hashtobase}}). The value of the ctr argument to hash2base MUST
+be 0 when instantiating an injective encoding. Thus, to map an octet string
+alpha to a point (x, y) using any of the encodings in this section, compute
 
 ~~~
 u = hash2base(alpha, 0)
 (x, y) = map2curve(u)
 ~~~
 
-Note that the output (x, y) is not a uniformly random point; see {{rom}}.
+Note that the output (x, y) is not a uniformly random point. If uniformity
+is required for security, the construction of {{rom}} MUST be used instead.
 
 ## Notation
 


### PR DESCRIPTION
This updates hash2base to use the same method described in the Pairing WG's BLS signatures [spec-v1](https://github.com/pairingwg/bls_standard/blob/master/minutes/spec-v1.md).

Executive summary:

The idea behind this change is that it makes it possible to call hash2base multiple times (for the random oracle construction) while hashing the input message exactly once. This avoids requiring applications to specify pre-hashing and also avoids requiring implementors to make non-black-box use of a hash function (e.g., computing a "partial" hash of a message and then "finishing" the hash in two different ways to get the two different evaluations for the random oracle construction).

One potential downside of this change is that it requires adding an argument `ctr` to all of the map2curve functions, which is "passed through" to hash2base. (This PR makes that change.) To address this slight ugliness, this PR makes `ctr` optional and defaults it to 0 if not specified. That way, one can still sensibly refer to a value like `map2curve(alpha)`.

Details:

The reasoning is as follows. In the current hash2base, one might want to call, say,

    hash2base(msg || I2OSP(1, 1))
    hash2base(msg || I2OSP(2, 1))

and this results in computing, inside the hash2base calls,

    m_prime_1 = H(msg || I2OSP(1, 1))
    m_prime_2 = H(msg || I2OSP(2, 1))

If `msg` is long, this is inefficient. One way to avoid this is, as I mentioned above, to "partially evaluate" H on `msg`. But requiring implementors to make non-black-box use of H is undesirable, because it constrains their implementations (for example, what happens if your crypto library doesn't let you partially evaluate H?).

The other way to avoid this is to make applications pre-hash messages. That's fine, but requiring them to do that for efficiency is a little unfriendly, because it means that if they forget to specify pre-hashing in their protocol, they have to change the protocol to fix it.

This PR gives a third option: call

    hash2base(msg, 1)
    hash2base(msg, 2)

This results in computing, inside the hash2base calls,

    m_prime_1 = H(msg) || I2OSP(1, 1)
    m_prime_2 = H(msg) || I2OSP(2, 1)

Since the concatenation is outside the call to H, both invocations of hash2base can share the same evaluation of `H(msg)`. This allows seamlessly optimizing the implementation of hash2base in a way that is guaranteed to be backward compatible, which means that applications do not have to worry about breaking changes that come as a result of pre-hashing.